### PR TITLE
Update joomla to 3.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM richarvey/nginx-php-fpm:php7
 MAINTAINER Terry Chen <seterrychen@gmail.com>
 
 ENV \
-  JOOMLA_VERSION=3.6.0 \
-  JOOMLA_SHA1=9e71357f689218705b15e653b7cdd57b498d4fa4 \
+  JOOMLA_VERSION=3.8.1 \
+  JOOMLA_SHA1=b31e97ef16e6030156600b4b9e8073eaf3b28928 \
+  JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1 \
+  WEBROOT=/var/joomla \
   DB_NAME=joomla \
   DB_USER=joomla \
   DB_PASSWORD=joomla \
@@ -12,12 +14,12 @@ ENV \
 RUN curl -o joomla.zip -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.zip \
   && echo "$JOOMLA_SHA1 *joomla.zip" | sha1sum -c - \
   && rm /var/www/html/index.php \
-  && mkdir /var/joomla \
-  && unzip joomla.zip -d /var/joomla \
-  && chown -R nginx:nginx /var/joomla \
+  && mkdir $WEBROOT \
+  && unzip joomla.zip -d $WEBROOT \
+  && chown -R nginx:nginx $WEBROOT \
   && rm joomla.zip
 
-RUN sed -r 's|^(Options -Indexes.*)$|#\1|' /var/joomla/htaccess.txt > /var/joomla/.htaccess
+RUN sed -r 's|^(Options -Indexes.*)$|#\1|' /var/joomla/htaccess.txt > ${WEBROOT}/.htaccess
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # joomla-nginx-fpm
 
-Joomla on Nginx. Using php7 7.0.8, Nginx 1.10.1 and Alpine 3.4.
+Joomla on Nginx. Using php7 7.0.14, Nginx 1.11.5 and Alpine 3.4@edge.
 
 ## Usage
 ```
@@ -9,16 +9,14 @@ docker run -d -p 8080:80 \
            -e DB_USER=joomla \
            -e DB_PASSWORD=joomla \
            -e DB_NAME=joomla \
-           -e JOOMLA_RELATIVE_URL_ROOT=/joomla
-           --link some-db:mysql seterrychen/joomla-nginx-fpm:3.6.0
+           --link some-db:mysql seterrychen/joomla-nginx-fpm:3.8.1
 ```
-Browse to http://localhost:8080/joomla/ to setup your Joomla.
+Browse to http://localhost:8080/ to setup your Joomla.
 
 - **DB_HOST**: no default value
 - **DB_USER**: default value is joomla
 - **DB_PASSWORD**: default value is joomla
 - **DB_NAME**: default value is joomla
-- **JOOMLA_RELATIVE_URL_ROOT**: no default value
 - **IPV6_LISTEN**: default value is fault to close IPV6 listener
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,9 @@
 #!/bin/bash
 
-JOOMLA_HOME=/var/joomla
-sed -i 's|default="localhost"|default="'"$DB_HOST"'"|' $JOOMLA_HOME/installation/model/forms/database.xml
-sed -i 's|label="INSTL_DATABASE_USER_LABEL"$|label="INSTL_DATABASE_USER_LABEL" default="'"$DB_USER"'"|' $JOOMLA_HOME/installation/model/forms/database.xml
-sed -i 's|label="INSTL_DATABASE_PASSWORD_LABEL"$|label="INSTL_DATABASE_PASSWORD_LABEL" default="'"$DB_PASSWORD"'"|' $JOOMLA_HOME/installation/model/forms/database.xml
-sed -i 's|label="INSTL_DATABASE_NAME_LABEL"$|label="INSTL_DATABASE_NAME_LABEL" default="'"$DB_NAME"'"|' $JOOMLA_HOME/installation/model/forms/database.xml
-
-# setting RELATIVE_URL_ROOT
-if [ x"$JOOMLA_RELATIVE_URL_ROOT" != x"" ]; then
-  sed -i 's|location / |location '"$JOOMLA_RELATIVE_URL_ROOT"'/ |' /etc/nginx/sites-available/default.conf
-  sed -i 's|$uri/ /index.php|$uri/ '"$JOOMLA_RELATIVE_URL_ROOT"'/index.php|' /etc/nginx/sites-available/default.conf
-  ln -s /var/joomla /var/www/html$JOOMLA_RELATIVE_URL_ROOT
-else
-  rm -r /var/www/html
-  ln -s /var/joomla /var/www/html
-fi
+sed -i 's|default="localhost"|default="'"$DB_HOST"'"|' $WEBROOT/installation/model/forms/database.xml
+sed -i 's|label="INSTL_DATABASE_USER_LABEL"$|label="INSTL_DATABASE_USER_LABEL" default="'"$DB_USER"'"|' $WEBROOT/installation/model/forms/database.xml
+sed -i 's|label="INSTL_DATABASE_PASSWORD_LABEL"$|label="INSTL_DATABASE_PASSWORD_LABEL" default="'"$DB_PASSWORD"'"|' $WEBROOT/installation/model/forms/database.xml
+sed -i 's|label="INSTL_DATABASE_NAME_LABEL"$|label="INSTL_DATABASE_NAME_LABEL" default="'"$DB_NAME"'"|' $WEBROOT/installation/model/forms/database.xml
 
 # setting ipv6 config
 if [ x"$IPV6_LISTEN" == x"false" ]; then


### PR DESCRIPTION
1. Update joomla to 3.8.1 and disable localhost checking issue ([issue reference](https://docs.joomla.org/J3.x:Secured_procedure_for_installing_Joomla_with_a_remote_database)).

2. `rm -r /var/www/html` will get a error message "Resource busy" because `/var/www/html` has been mounted in base image `richarvey/nginx-php-fpm:php7`.